### PR TITLE
Feat/user cookbooks

### DIFF
--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -15,8 +15,10 @@ class Api::V1::SessionsController < ApplicationController
                     id: user.id,
                     first_name: user.first_name,
                     last_name: user.last_name,
-                    user_name: user.user_name,
-                    slug: user.slug
+                    username: user.user_name,
+                    slug: user.slug,
+                    primary_cookbook_id: user.cookbooks[0]&.id,
+                    cookbook_count: user.cookbooks.count
                 },
                 roles: user.roles
             }, status: :ok

--- a/app/models/cookbook.rb
+++ b/app/models/cookbook.rb
@@ -1,5 +1,4 @@
 class Cookbook < ApplicationRecord
-    rolify
     belongs_to :user
     has_many :cookbook_recipes
     has_many :recipes, through: :cookbook_recipes
@@ -7,4 +6,15 @@ class Cookbook < ApplicationRecord
     has_many :tags, through: :cookbook_tags
 
     validates :cookbook_name, presence: true
+
+    before_destroy :ensure_user_has_other_cookbooks
+
+    private
+
+    def ensure_user_has_other_cookbooks
+        if user.cookbooks.limit(2).count <= 1
+            errors.add(:base, "Cannot delete last cookbook.")
+            throw(:abort)
+        end
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,18 +28,6 @@ class User < ApplicationRecord
         self.add_role(:owner, cookbook)
     end
 
-    def admin?
-        roles.exists?(name: "admin")
-    end
-
-    def user?
-        roles.exists?(name: "user")
-    end
-
-    def editor?
-        roles.exists?(name: "editor")
-    end
-
     def set_role(role_name)
         unless has_role?(role_name)
             self.add_role(role_name)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,12 +17,15 @@ class User < ApplicationRecord
     has_secure_password
 
     after_create :assign_default_role
-
-
+    after_create :create_default_cookbook
 
     def assign_default_role
-        user_role = Role.find_or_create_by(name: "user")
-        roles << user_role unless roles.include?(user_role)
+        self.add_role(:user)
+    end
+
+    def create_default_cookbook
+        cookbook = self.cookbooks.create!(cookbook_name: "#{first_name}'s Cookbook")
+        self.add_role(:owner, cookbook)
     end
 
     def admin?
@@ -38,8 +41,9 @@ class User < ApplicationRecord
     end
 
     def set_role(role_name)
-        self.roles.destroy_all
-        self.add_role(role_name)
+        unless has_role?(role_name)
+            self.add_role(role_name)
+        end
     end
 
     def set_user_name

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
     rolify
     PASSWORD_REGEXP = /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^A-Za-z0-9])(.{12,})\z/
 
-    has_one :cookbook
+    has_many :cookbooks
     has_many :user_recipe_modifications
     has_and_belongs_to_many :roles, join_table: :users_roles
 

--- a/app/policies/cookbook_policy.rb
+++ b/app/policies/cookbook_policy.rb
@@ -8,7 +8,11 @@ class CookbookPolicy < ApplicationPolicy
   end
 
   def destroy?
-    user&.has_role?(:admin)
+    return false if user.nil?
+    return true if user.has_role?(:admin)
+
+    user_cookbook_count = user.cookbooks.limit(2).count
+    user == record.user && user_cookbook_count > 1
   end
 
   class Scope < ApplicationPolicy::Scope

--- a/app/policies/cookbook_policy.rb
+++ b/app/policies/cookbook_policy.rb
@@ -1,22 +1,24 @@
 class CookbookPolicy < ApplicationPolicy
   def show?
-    user.admin? || record.user == user
+    record.public? || record.user == user || user&.has_role?(:admin)
   end
 
   def update?
-    user.admin? || record.user == user
+    user && (record.user == user || user.has_role?(:editor, record) || user.has_role?(:admin))
   end
 
   def destroy?
-    user.admin?
+    user&.has_role?(:admin)
   end
 
   class Scope < ApplicationPolicy::Scope
     def resolve
-      if user.admin?
+      if user&.has_role?(:admin)
         scope.all
+      elsif user
+        scope.where("public = ? OR user_id = ?", true, user.id)
       else
-        scope.where(user_id: user.id)
+        scope.where(public: true)
       end
     end
   end

--- a/app/policies/cookbook_policy.rb
+++ b/app/policies/cookbook_policy.rb
@@ -1,6 +1,6 @@
 class CookbookPolicy < ApplicationPolicy
   def show?
-    record.public? || record.user == user || user&.has_role?(:admin)
+    !!(record.public? || record.user == user || user&.has_role?(:admin))
   end
 
   def update?

--- a/db/migrate/20250718152455_add_public_to_cookbooks.rb
+++ b/db/migrate/20250718152455_add_public_to_cookbooks.rb
@@ -1,0 +1,5 @@
+class AddPublicToCookbooks < ActiveRecord::Migration[8.0]
+  def change
+    add_column :cookbooks, :public, :boolean, default: true, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2025_06_19_195908) do
+ActiveRecord::Schema[8.0].define(version: 2025_07_18_152455) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -38,6 +38,7 @@ ActiveRecord::Schema[8.0].define(version: 2025_06_19_195908) do
     t.bigint "user_id", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "public", default: true, null: false
     t.index ["user_id"], name: "index_cookbooks_on_user_id"
   end
 

--- a/spec/models/cookbook_spec.rb
+++ b/spec/models/cookbook_spec.rb
@@ -12,4 +12,31 @@ RSpec.describe Cookbook, type: :model do
     describe "validations" do
         it { should validate_presence_of(:cookbook_name) }
     end
+
+    describe "callbacks" do
+        let(:user) { create(:user) }
+
+        context "when user has only one cookbook" do
+            it "does not allow destroying the last cookbook" do
+                count = user.cookbooks.count
+                cookbook = user.cookbooks.first
+                p count
+                result = cookbook.destroy
+
+                expect(result).to be_falsey
+                expect(cookbook.errors[:base]).to include("Cannot delete last cookbook.")
+            end
+        end
+
+        context "when user has multiple cookbooks" do
+            let!(:cookbook1) { create(:cookbook, user: user) }
+            let!(:cookbook2) { create(:cookbook, user: user) }
+
+            it "allows destroying a cookbook" do
+                expect {
+                    expect(cookbook1.destroy).to be_truthy
+                }.to change(Cookbook, :count).by(-1)
+            end
+        end
+    end
 end

--- a/spec/policies/cookbook_policy_spec.rb
+++ b/spec/policies/cookbook_policy_spec.rb
@@ -92,12 +92,18 @@ RSpec.describe CookbookPolicy, type: :policy do
       expect(subject.new(admin_user, cookbook).destroy?).to be true
     end
 
+    it "allows users to destroy their cookbooks as long as they have more than one" do
+      expect(subject.new(regular_user, cookbook).destroy?).to be true
+    end
+
     it "prevents user from destroying someone else's cookbook" do
       expect(subject.new(regular_user, other_cookbook).destroy?).to be false
     end
 
     it "prevents user from destroying their own cookbook" do
-      expect(subject.new(regular_user, cookbook).destroy?).to be false
+      single_cookbook_user = create(:user)
+      only_cookbook = single_cookbook_user.cookbooks[0]
+      expect(subject.new(single_cookbook_user, only_cookbook).destroy?).to be false
     end
   end
 end

--- a/spec/policies/cookbook_policy_spec.rb
+++ b/spec/policies/cookbook_policy_spec.rb
@@ -1,34 +1,48 @@
 require 'rails_helper'
 
 RSpec.describe CookbookPolicy, type: :policy do
-  let(:admin_role) { Role.find(name: 'admin') }
-  let(:user_role) { Role.find(name: 'user') }
+  let(:admin_role) { Role.find_or_create_by(name: 'admin') }
+  let(:user_role) { Role.find_or_create_by(name: 'user') }
 
-  let(:admin_user) { User.create!(first_name: 'Admin', last_name: 'User', user_name: 'admin_user', password: 'Password01234!') }
-  let(:regular_user) { User.create!(first_name: 'Regular', last_name: 'User', user_name: 'regular_user', password: 'Password01234!') }
+  let(:admin_user) { User.create!(first_name: 'Admin', last_name: 'User', email: "admin@example.com", user_name: 'admin_user', password: 'Password01234!') }
+  let(:regular_user) { User.create!(first_name: 'Regular', last_name: 'User', email: "regular@example.com", user_name: 'regular_user', password: 'Password01234!') }
+  let(:other_user) { User.create!(first_name: 'Other', last_name: 'User', email: "other@example.com", user_name: 'other_user', password: 'Password01234!') }
 
   before do
-    admin_user.roles << admin_role
-    regular_user.roles << user_role
+    admin_user.add_role(:admin)
+    regular_user.add_role(:user)
+    other_user.add_role(:user)
   end
 
-  let(:cookbook) { Cookbook.create!(cookbook_name: "Testy Test", user: regular_user) }
-  let(:other_user_cookbook) { create(:cookbook, user: (create(:user))) }
+  let(:cookbook) { Cookbook.create!(cookbook_name: "Testy Test", user: regular_user, public: false) }
+  let(:public_cookbook) { Cookbook.create!(cookbook_name: "Public Taste", user: other_user, public: true) }
+  let(:other_cookbook) { Cookbook.create!(cookbook_name: "Other Private Cookbook", user: other_user, public: false) }
 
   subject { described_class }
 
   describe '.scope' do
-    it "allows admin to see all cookbooks" do
-      policy_scope = CookbookPolicy::Scope.new(admin_user, Cookbook.all).resolve
-      expect(policy_scope.to_a).to eq(Cookbook.all.to_a)
+    before(:each) do
+      cookbook.reload
+      public_cookbook.reload
+      other_cookbook.reload
     end
 
-    it "allows user to see only their own cookbooks" do
-      policy_scope = CookbookPolicy::Scope.new(regular_user, Cookbook.all).resolve
-      regular_user.reload
-      cookbook.reload
+    it "allows admin to see all cookbooks" do
+      policy_scope = CookbookPolicy::Scope.new(admin_user, Cookbook.all).resolve
+      expect(policy_scope.to_a).to include(cookbook, public_cookbook, other_cookbook)
+    end
 
-      expect(policy_scope.to_a).to eq([ cookbook ])
+    it "allows user to see their own cookbooks and all public cookbooks" do
+      policy_scope = CookbookPolicy::Scope.new(regular_user, Cookbook.all).resolve
+
+      expect(policy_scope.to_a).to include(cookbook, public_cookbook)
+      expect(policy_scope.to_a).not_to include(other_cookbook)
+    end
+
+    it "allows guests to see only public cookbooks" do
+      policy_scope = CookbookPolicy::Scope.new(nil, Cookbook.all).resolve
+
+      expect(policy_scope.to_a).to include(public_cookbook)
     end
   end
 
@@ -37,12 +51,21 @@ RSpec.describe CookbookPolicy, type: :policy do
       expect(subject.new(admin_user, cookbook).show?).to be true
     end
 
-    it "allows user to view their own cookbook" do
+    it "allows user to view their own cookbook and public cookbooks" do
       expect(subject.new(regular_user, cookbook).show?).to be true
+      expect(subject.new(regular_user, public_cookbook).show?).to be true
     end
 
-    it "prevents user from viewing someone else's cookbook" do
-      expect(subject.new(regular_user, other_user_cookbook).show?).to be false
+    it "allows guests to view public cookbooks" do
+      expect(subject.new(nil, public_cookbook).show?).to be true
+    end
+
+    it "prevents user from viewing someone else's private cookbook" do
+      expect(subject.new(regular_user, other_cookbook).show?).to be false
+    end
+
+    it "prevents guest from viewing someone else's private cookbook" do
+      expect(subject.new(nil, other_cookbook).show?).to be false
     end
   end
 
@@ -55,8 +78,12 @@ RSpec.describe CookbookPolicy, type: :policy do
       expect(subject.new(regular_user, cookbook).update?).to be true
     end
 
-    it "prevents user from updating someone else's cookbook" do
-      expect(subject.new(regular_user, other_user_cookbook).update?).to be false
+    it "prevents user from updating someone's public cookbook" do
+      expect(subject.new(regular_user, public_cookbook).update?).to be false
+    end
+
+    it "prevents user from updating someone else's private cookbook" do
+      expect(subject.new(regular_user, other_cookbook).update?).to be false
     end
   end
 
@@ -66,7 +93,7 @@ RSpec.describe CookbookPolicy, type: :policy do
     end
 
     it "prevents user from destroying someone else's cookbook" do
-      expect(subject.new(regular_user, other_user_cookbook).destroy?).to be false
+      expect(subject.new(regular_user, other_cookbook).destroy?).to be false
     end
 
     it "prevents user from destroying their own cookbook" do

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 describe "Sessions Controller", type: :request do
     let!(:user) { create(:user) }
+    let!(:cookbook1) { create(:cookbook, user: user) }
+    let!(:cookbook2) { create(:cookbook, user: user) }
 
     it "logs in a user with valid email and password" do
         post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
@@ -29,5 +31,57 @@ describe "Sessions Controller", type: :request do
 
         expect(response).to have_http_status(:unauthorized)
         expect(JSON.parse(response.body)).to include("error")
+    end
+
+    it "returns a valid JSON response with primary_cookbook_id and cookbook_count" do
+        post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
+
+        expect(response).to have_http_status(:ok)
+
+        json = JSON.parse(response.body)
+
+        # Check keys exist
+        expect(json).to include("token", "user", "roles")
+
+        user_data = json["user"]
+
+        expect(user_data).to include(
+            "id",
+            "first_name",
+            "last_name",
+            "username",
+            "slug",
+            "primary_cookbook_id",
+            "cookbook_count"
+        )
+
+        expect(user_data["id"]).to be_a(Integer)
+        expect(user_data["first_name"]).to be_a(String)
+        expect(user_data["last_name"]).to be_a(String)
+        expect(user_data["username"]).to be_a(String)
+        expect(user_data["slug"]).to be_a(String)
+        expect(user_data["primary_cookbook_id"]).to be_a(Integer).or be_nil
+        expect(user_data["cookbook_count"]).to eq(2)
+    end
+
+    context "when user has no cookbooks" do
+        let!(:user_without_cookbooks) { create(:user) }
+        let(:params) do
+            {
+                username: user_without_cookbooks.user_name,
+                password: user_without_cookbooks.password
+            }
+        end
+
+        it "returns nil for primary_cookbook_id and zero for cookbook_count" do
+            post "/api/v1/login", params: params
+
+            expect(response).to have_http_status(:ok)
+            json = JSON.parse(response.body)
+            user_data = json["user"]
+
+            expect(user_data["primary_cookbook_id"]).to be_nil
+            expect(user_data["cookbook_count"]).to eq(0)
+        end
     end
 end


### PR DESCRIPTION
Updated cookbook model and cookbook policy to include public (boolean) attribute to allow guests and users to view specific cookbooks.
Modified user to allow for multiple cookbooks to be assigned to one user. 
Updated usage with rolify and pundit to utilize source specific roles (i.e. owner of cookbook vs general user)