### PR TITLE
Feat/cookbook resolvers

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,47 @@ Get started by making sure that ruby is installed on your computer so that you'l
 
 ## Usage
 
+### Registering a user:
+
+Endpoint: `/graphql`
+<br><br>
+Required variables:
+
+```json
+{
+  "query": "mutation RegisterUser($input: RegisterUserInput!) { registerUser(input: $input) { user { id firstName lastName email } token errors } }",
+  "variables": {
+    "input": {
+      "firstName": "$firstName",
+      "lastName": "$lastName",
+      "email": "$email",
+      "password": "$password",
+      "passwordConfirmation": "$passwordConfirmation"
+    }
+  },
+  "operationName": "RegisterUser"
+}
+```
+
+Expected response:
+
+```json
+{
+  "data": {
+    "registerUser": {
+      "user": {
+        "id": "1",
+        "firstName": "Steve",
+        "lastName": "Erwin",
+        "email": "SErwin@example.com"
+      },
+      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", // JWT or similar
+      "errors": []
+    }
+  }
+}
+```
+
 ### Signing in a user:
 
 Endpoint: `/login`
@@ -195,49 +236,6 @@ Required variables:
 
 <br>
 
-**Expected Response:**
-
-```json
-{
-  "data": {
-    "recipes": [
-      {
-        "id": "1",
-        "name": "360 Deli"
-      },
-      {
-        "id": "2",
-        "name": "WBL House"
-      },
-      {
-        "id": "3",
-        "name": "Fat Grill"
-      },
-      {
-        "id": "4",
-        "name": "Sugar Deli"
-      }
-    ]
-  }
-}
-```
-
-#### **Personal Cookbook**
-
-Endpoint: `/graphql`
-<br><br>
-If you want to get all the recipes associated to the logged in users cookbook. <br>
-**Required variables:**
-
-```json
-{
-  "query": "query GetPersonalCookbook { personalCookbook { id name image servingSize } }",
-  "variables": {},
-  "operationName": "GetPersonalCookbook"
-}
-```
-
-<br><br>
 Expected Response:
 
 ```json
@@ -267,48 +265,285 @@ Expected Response:
 
 #### **Random Recipes**
 
-Endpoint: `/graphql`
-<br><br>
-Fetch a random amount of recipes. Pass the number as the count variable (optional). <br>
-
-**Required variables:**
-
-```json
-{
-  "query": "query GetRandomRecipes($count: Int) { randomRecipes(count: $count) { id name image servingSize } }",
-  "variables": { "count": 5 },
-  "operationName": "GetRandomRecipes"
-}
-```
-
-<br><br>
-Expected Response:
-
-```json
-
-```
-
-#### **Single Recipe**
+An endpoint to get a random assortment of recipes, default is 5 recipes but can take in a variable to take in more or less depending on the needs of the user.
 
 Endpoint: `/graphql`
 <br><br>
-Fetch a single recipes full information by ID. <br>
-
-**Required variables:**
+Required variables:
 
 ```json
 {
-  "query": "query GetRecipe($id: ID!) { recipe(id: $id) { id name image servingSize recipeInstructions { instructionStep instruction } recipeIngredients { quantity measurement { unit } ingredient { name } } } }",
-  "variables": { "id": "RECIPE_ID_HERE" },
-  "operationName": "GetRecipe"
+  "query": "query RandomRecipes($count: Int) { randomRecipes(count: $count) { id name image servingSize } }",
+  "variables": { "count": 9 },
+  "operationName": "RandomRecipes"
 }
 ```
 
-<br><br>
 Expected Response:
 
 ```json
+{
+  "data": {
+    "randomRecipes": [
+      {
+        "id": "1",
+        "name": "Spicy Thai Noodles",
+        "image": "https://loremflickr.com/300/300/food?lock=1",
+        "servingSize": 2
+      },
+      {
+        "id": "2",
+        "name": "Grilled Lemon Chicken",
+        "image": "https://loremflickr.com/300/300/food?lock=2",
+        "servingSize": 4
+      },
 
+      ...
+
+      {
+        "id": "9",
+        "name": "Vegan Burrito Bowl",
+        "image": "https://loremflickr.com/300/300/food?lock=9",
+        "servingSize": 3
+      }
+    ]
+  }
+}
+```
+
+#### **Full Recipe Data**
+
+An endpoint to get all the data associated with a single recipe.
+
+Endpoint: `/graphql`
+<br><br>
+Required variables:
+
+```json
+{
+  "query": "query OneRecipe($id: ID!) { oneRecipe(id: $id) { id name image servingSize recipeInstructions { instructionStep instruction } recipeIngredients { quantity measurement { unit } ingredient { name } } } }",
+  "variables": { "id": 1234 },
+  "operationName": "OneRecipe"
+}
+```
+
+Expected Response:
+
+```json
+{
+  "data": {
+    "oneRecipe": {
+      "id": "1234",
+      "name": "Grilled Lemon Chicken",
+      "image": "https://loremflickr.com/300/300/food?lock=1234",
+      "servingSize": 4,
+      "recipeInstructions": [
+        {
+          "instructionStep": 1,
+          "instruction": "Preheat grill to medium-high heat."
+        },
+        {
+          "instructionStep": 2,
+          "instruction": "Marinate chicken in lemon juice, garlic, and herbs for 30 minutes."
+        },
+        {
+          "instructionStep": 3,
+          "instruction": "Grill chicken for 6–8 minutes per side or until fully cooked."
+        }
+      ],
+      "recipeIngredients": [
+        {
+          "quantity": "2",
+          "measurement": {
+            "unit": "pieces"
+          },
+          "ingredient": {
+            "name": "Chicken breasts"
+          }
+        },
+        {
+          "quantity": "1",
+          "measurement": {
+            "unit": "tbsp"
+          },
+          "ingredient": {
+            "name": "Olive oil"
+          }
+        },
+        {
+          "quantity": "2",
+          "measurement": {
+            "unit": "tbsp"
+          },
+          "ingredient": {
+            "name": "Lemon juice"
+          }
+        },
+        {
+          "quantity": "1",
+          "measurement": {
+            "unit": "tsp"
+          },
+          "ingredient": {
+            "name": "Garlic (minced)"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Querying for cookbooks
+
+#### **Public Cookbooks**
+
+An endpoint to get all the public cookbooks available and will return a list dependent on if a guest, a user, or admin is making the request. The current user is what defines what is returned.
+
+Endpoint: `/graphql`
+<br><br>
+Required variables:
+
+```json
+{
+  "query": "query PublicCookbooks { publicCookbooks { id cookbookName public user { id } } }",
+  "operationName": "PublicCookbooks"
+}
+```
+
+Expected Response:
+
+```json
+{
+  "data": {
+    "publicCookbooks": [
+      {
+        "id": "1",
+        "cookbookName": "Weeknight Dinners",
+        "public": true,
+        "user": {
+          "id": "101"
+        }
+      },
+      {
+        "id": "2",
+        "cookbookName": "Vegan Favorites",
+        "public": true,
+        "user": {
+          "id": "102"
+        }
+      },
+      {
+        "id": "3",
+        "cookbookName": "Family Classics",
+        "public": true,
+        "user": {
+          "id": "103"
+        }
+      }
+    ]
+  }
+}
+```
+
+#### **User Cookbooks**
+
+An endpoint to get all the cookbooks owned by the current user.
+
+Endpoint: `/graphql`
+<br><br>
+Required variables:
+
+```json
+{
+  "query": "query UserCookbooks { userCookbooks { id cookbookName public user { id } } }",
+  "operationName": "UserCookbooks"
+}
+```
+
+Expected Response:
+
+```json
+{
+  "data": {
+    "publicCookbooks": [
+      {
+        "id": "1",
+        "cookbookName": "Weeknight Dinners",
+        "public": true,
+        "user": {
+          "id": "101"
+        }
+      },
+      {
+        "id": "2",
+        "cookbookName": "Vegan Favorites",
+        "public": false,
+        "user": {
+          "id": "101"
+        }
+      },
+      {
+        "id": "3",
+        "cookbookName": "Family Classics",
+        "public": true,
+        "user": {
+          "id": "101"
+        }
+      }
+    ]
+  }
+}
+```
+
+#### **Cookbook Recipes**
+
+An endpoint to get all the recipes associated with a specific cookbook.
+
+Endpoint: `/graphql`
+<br><br>
+Required variables:
+
+```json
+{
+  "query": "query CookbookRecipes ($id: ID!) { cookbookRecipes (id: $id) { id cookbookName public user { id } recipes { id name image } } }",
+  "variables": { "id": 1 },
+  "operationName": "CookbookRecipes"
+}
+```
+
+Expected Response:
+
+```json
+{
+  "data": {
+    "cookbookRecipes": {
+      "id": "1",
+      "cookbookName": "Mediterranean Meals",
+      "public": true,
+      "user": {
+        "id": "301"
+      },
+      "recipes": [
+        {
+          "id": "101",
+          "name": "Greek Salad",
+          "image": "https://loremflickr.com/300/300/food?lock=101"
+        },
+        {
+          "id": "102",
+          "name": "Lemon Herb Chicken",
+          "image": "https://loremflickr.com/300/300/food?lock=102"
+        },
+        {
+          "id": "103",
+          "name": "Stuffed Peppers",
+          "image": "https://loremflickr.com/300/300/food?lock=103"
+        }
+      ]
+    }
+  }
+}
 ```
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
@@ -317,7 +552,7 @@ Expected Response:
 
 ## Roadmap
 
-- [x] Add Changelog
+- [ ] Add Changelog
 - [x] Add back to top links
 - [ ] Add Additional Templates w/ Examples
 - [ ] Add "components" document to easily copy & paste sections of the readme
@@ -325,7 +560,7 @@ Expected Response:
   - [ ] Chinese
   - [ ] Spanish
 
-See the [open issues](https://github.com/othneildrew/Best-README-Template/issues) for a full list of proposed features (and known issues).
+See the [open issues](https://github.com/users/Sgalvin36/projects/9/views/1) for a full list of proposed features (and known issues).
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 
@@ -346,7 +581,7 @@ Don't forget to give the project a star! Thanks again!
 
 ### Top contributors:
 
-<!-- <a href="https://github.com/othneildrew/Best-README-Template/graphs/contributors">
+<!-- <a href="https://github.com/Sgalvin36/creative_cooking_api/graphs/contributors">
   <img src="https://contrib.rocks/image?repo=othneildrew/Best-README-Template" alt="contrib.rocks image" />
 </a> -->
 
@@ -366,7 +601,8 @@ Distributed under the Unlicense License. See `LICENSE.txt` for more information.
 
 Shane Galvin - Sgalvin36@gmail.com
 
-Project Link: [https://github.com/Sgalvin36/creative_cooking_fe](https://github.com/Sgalvin36/creative_cooking_fe)
+Project Repo: [https://github.com/Sgalvin36/creative_cooking_api](https://github.com/Sgalvin36/creative_cooking_api)
+Associated Front End: [https://github.com/Sgalvin36/creative_cooking_fe](https://github.com/Sgalvin36/creative_cooking_fe)
 
 <p align="right">(<a href="#readme-top">back to top</a>)</p>
 

--- a/app/graphql/resolvers/all_public_cookbooks_resolver.rb
+++ b/app/graphql/resolvers/all_public_cookbooks_resolver.rb
@@ -1,0 +1,11 @@
+module Resolvers
+    class AllPublicCookbooksResolver < Resolvers::BaseResolver
+        type [ Types::CookbookType ], null: false
+
+        description "Returns all cookbooks that have been marked as public and are visible to anyone"
+
+        def resolve
+            Pundit.policy_scope!(context[:current_user], Cookbook).order(:cookbook_name)
+        end
+    end
+end

--- a/app/graphql/resolvers/cookbook_recipes_resolver.rb
+++ b/app/graphql/resolvers/cookbook_recipes_resolver.rb
@@ -1,5 +1,5 @@
 module Resolvers
-    class PersonalCookbookResolver < Resolvers::BaseResolver
+    class CookbookRecipesResolver < Resolvers::BaseResolver
         type [ Types::RecipeType ], null: false
 
         def resolve

--- a/app/graphql/resolvers/cookbook_recipes_resolver.rb
+++ b/app/graphql/resolvers/cookbook_recipes_resolver.rb
@@ -1,12 +1,15 @@
 module Resolvers
     class CookbookRecipesResolver < Resolvers::BaseResolver
-        type [ Types::RecipeType ], null: false
+        type Types::CookbookType, null: false
 
-        def resolve
-            user = context[:current_user]
-            return [] unless user&.cookbook
-            authorize(user.cookbook, :show?, policy_class: CookbookPolicy)
-            user.cookbook.recipes
+        description "Fetch a single cookbook (with recipes) by ID"
+
+        argument :id, ID, required: true
+
+        def resolve(id:)
+            cookbook = Cookbook.find(id)
+            Pundit.authorize(context[:current_user], cookbook, :show?)
+            cookbook
         end
     end
 end

--- a/app/graphql/resolvers/public_cookbooks_resolver.rb
+++ b/app/graphql/resolvers/public_cookbooks_resolver.rb
@@ -1,5 +1,5 @@
 module Resolvers
-    class AllPublicCookbooksResolver < Resolvers::BaseResolver
+    class PublicCookbooksResolver < Resolvers::BaseResolver
         type [ Types::CookbookType ], null: false
 
         description "Returns all cookbooks that have been marked as public and are visible to anyone"

--- a/app/graphql/resolvers/user_cookbooks_resolver.rb
+++ b/app/graphql/resolvers/user_cookbooks_resolver.rb
@@ -1,6 +1,6 @@
 module Resolvers
     class UserCookbooksResolver < Resolvers::BaseResolver
-        type [ Types::RecipeType ], null: false
+        type [ Types::CookbookType ], null: false
 
         description "Return only the user's public and private cookbooks"
 

--- a/app/graphql/resolvers/user_cookbooks_resolver.rb
+++ b/app/graphql/resolvers/user_cookbooks_resolver.rb
@@ -2,11 +2,10 @@ module Resolvers
     class UserCookbooksResolver < Resolvers::BaseResolver
         type [ Types::RecipeType ], null: false
 
+        description "Return only the user's public and private cookbooks"
+
         def resolve
-            user = context[:current_user]
-            return [] unless user&.cookbook
-            authorize(user.cookbook, :show?, policy_class: CookbookPolicy)
-            user.cookbook.recipes
+            Pundit.policy_scope!(context[:current_user], [ :owned, Cookbook ]).order(:cookbook_name)
         end
     end
 end

--- a/app/graphql/resolvers/user_cookbooks_resolver.rb
+++ b/app/graphql/resolvers/user_cookbooks_resolver.rb
@@ -1,0 +1,12 @@
+module Resolvers
+    class UserCookbooksResolver < Resolvers::BaseResolver
+        type [ Types::RecipeType ], null: false
+
+        def resolve
+            user = context[:current_user]
+            return [] unless user&.cookbook
+            authorize(user.cookbook, :show?, policy_class: CookbookPolicy)
+            user.cookbook.recipes
+        end
+    end
+end

--- a/app/graphql/types/cookbook_type.rb
+++ b/app/graphql/types/cookbook_type.rb
@@ -6,5 +6,10 @@ module Types
         field :user, Types::UserType, null: false
         field :recipes, [ Types::RecipeType ], null: false
         field :tags, [ Types::TagType ], null: true
+        field :can_edit, Boolean, null: false
+
+        def can_edit
+            Pundit.policy(context[:current_user], object).update?
+        end
     end
 end

--- a/app/graphql/types/cookbook_type.rb
+++ b/app/graphql/types/cookbook_type.rb
@@ -2,6 +2,7 @@ module Types
     class CookbookType < Types::BaseObject
         field :id, ID, null: false
         field :cookbook_name, String, null: false
+        field :public, Boolean, null: false
         field :user, Types::UserType, null: false
         field :recipes, [ Types::RecipeType ], null: false
         field :tags, [ Types::TagType ], null: true

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -10,7 +10,7 @@ module Types
 
       field :user_cookbooks, resolver: Resolvers::UserCookbooksResolver, description: "Fetch all cookbooks created by the currently signed-in user"
 
-      field :public_cookbooks, resolver: Resolvers::AllPublicCookbooksResolver, description: "Fetch all public cookbooks in database"
+      field :public_cookbooks, resolver: Resolvers::PublicCookbooksResolver, description: "Fetch all public cookbooks in database"
 
       field :cookbook_recipes, resolver: Resolvers::CookbookRecipesResolver, description: "Fetch all recipes from a specific cookbook ID. Must be public or owned by user."
   end

--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -2,9 +2,16 @@
 
 module Types
   class QueryType < Types::BaseObject
-      field :personal_cookbook, resolver: Resolvers::PersonalCookbookResolver
-      field :random_recipes, resolver: Resolvers::RandomRecipesResolver
-      field :all_recipes, resolver: Resolvers::AllRecipesResolver
-      field :one_recipe, resolver: Resolvers::OneRecipeResolver
+      field :random_recipes, resolver: Resolvers::RandomRecipesResolver, description: "Fetch random number of recipes with option to specify how many"
+
+      field :all_recipes, resolver: Resolvers::AllRecipesResolver, description: "Fetch all recipes, with search options available"
+
+      field :one_recipe, resolver: Resolvers::OneRecipeResolver, description: "Fetch all data for one recipe including ingredients and steps"
+
+      field :user_cookbooks, resolver: Resolvers::UserCookbooksResolver, description: "Fetch all cookbooks created by the currently signed-in user"
+
+      field :public_cookbooks, resolver: Resolvers::AllPublicCookbooksResolver, description: "Fetch all public cookbooks in database"
+
+      field :cookbook_recipes, resolver: Resolvers::CookbookRecipesResolver, description: "Fetch all recipes from a specific cookbook ID. Must be public or owned by user."
   end
 end

--- a/app/policies/cookbook_policy.rb
+++ b/app/policies/cookbook_policy.rb
@@ -26,4 +26,10 @@ class CookbookPolicy < ApplicationPolicy
       end
     end
   end
+
+  class OwnedScope < Scope
+    def resolve
+      scope.where("user_id = ?", user.id)
+    end
+  end
 end

--- a/config/initializers/pundit_named_scope.rb
+++ b/config/initializers/pundit_named_scope.rb
@@ -1,0 +1,14 @@
+module Pundit
+    def self.policy_scope!(user, scope)
+        if scope.is_a?(Array)
+            scope_name, model = scope
+            scope_class_name = "#{model}Policy::#{scope_name.to_s.camelize}Scope"
+            scope_class = scope_class_name.constantize
+            scope_class.new(user, model.all).resolve
+        else
+            policy_scope = policy_scope(user, scope)
+            raise NotDefinedError, "unable to find policy scope for #{scope}" unless policy_scope
+            policy_scope
+        end
+    end
+end

--- a/spec/factories/cookbook_recipes.rb
+++ b/spec/factories/cookbook_recipes.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+    factory :cookbook_recipe do
+        cookbook
+        recipe
+    end
+end

--- a/spec/factories/cookbooks.rb
+++ b/spec/factories/cookbooks.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
     factory :cookbook do
         cookbook_name { Faker::Books::CultureSeries.book }
+        public { true }
         association :user
     end
 end

--- a/spec/factories/recipes.rb
+++ b/spec/factories/recipes.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
     factory :recipe do
         name { Faker::Restaurant.name }
-        image { "https://arthurmillerfoundation.org/wp-content/uploads/2018/06/default-placeholder.png" }
+        # image { "https://arthurmillerfoundation.org/wp-content/uploads/2018/06/default-placeholder.png" }
+        image { Faker::LoremFlickr.image(size: "300x300", search_terms: [ 'food' ]) }
         serving_size { Faker::Number.between(from: 1, to: 10) }
     end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -7,8 +7,10 @@ FactoryBot.define do
         password { "Passwords123!" }
         password_confirmation { "Passwords123!" }
 
-        after(:create) do |user|
-            user.add_role(:user) if user.roles.blank?
+        trait :admin do
+            after(:create) do |user|
+                user.add_role(:admin)
+            end
         end
     end
 end

--- a/spec/policies/cookbook_policy_spec.rb
+++ b/spec/policies/cookbook_policy_spec.rb
@@ -44,6 +44,13 @@ RSpec.describe CookbookPolicy, type: :policy do
 
       expect(policy_scope.to_a).to include(public_cookbook)
     end
+
+    it "allows user to see their own cookbooks without any other public cookbooks" do
+      policy_scope = CookbookPolicy::OwnedScope.new(regular_user, Cookbook.all).resolve
+
+      expect(policy_scope.to_a).to include(cookbook)
+      expect(policy_scope.to_a).not_to include(public_cookbook, other_cookbook)
+    end
   end
 
   describe '#show?' do

--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -2,29 +2,24 @@ require 'rails_helper'
 
 RSpec.describe "GraphQL API", type: :request do
     let(:user) { create(:user) }
-    let(:login_params) do
-        {
-            email: user.email,
-            password: user.password
-        }
-    end
+    let(:admin) { create(:user, :admin) }
 
-    let(:auth_token) do
-        post "/api/v1/login", params: login_params
-        JSON.parse(response.body)["token"]
-    end
 
-    let(:headers) do
-        {
-            "Authorization" => "Bearer #{auth_token}",
-            "Content-Type" => "application/json"
-        }
+    def auth_headers(user = nil)
+        if user
+            token = JsonWebToken.encode(user_id: user.id)
+            {
+                "Authorization" => "Bearer #{token}",
+                "Content-Type" => "application/json"
+            }
+        else
+            { "Content-Type" => "application/json" }
+        end
     end
 
     describe "Queries" do
         describe "RandomRecipes" do
             let!(:recipes) { create_list(:recipe, 10) }
-            let!(:user) { create(:user) }
 
             let(:query) do
                 <<~GRAPHQL
@@ -40,7 +35,7 @@ RSpec.describe "GraphQL API", type: :request do
             end
 
             it "returns the default number of random recipes (5)" do
-                post "/api/v1/graphql", params: { query: query }
+                post api_v1_graphql_path, params: { query: query }.to_json, headers: auth_headers(nil)
 
                 json = JSON.parse(response.body)
                 data = json["data"]["randomRecipes"]
@@ -51,8 +46,7 @@ RSpec.describe "GraphQL API", type: :request do
             end
 
             it "returns a custom number of random recipes when count is specified" do
-                post "/api/v1/graphql", params: { query: query, variables: { count: 3 }.to_json }
-
+                post api_v1_graphql_path, params: { query: query, variables: { count: 3 } }.to_json, headers: auth_headers(nil)
                 json = JSON.parse(response.body)
                 data = json["data"]["randomRecipes"]
 
@@ -62,7 +56,7 @@ RSpec.describe "GraphQL API", type: :request do
             end
 
             it "returns the default number of random recipes when count is out of range (< 1)" do
-                post "/api/v1/graphql", params: { query: query, variables: { count: -4 }.to_json }
+                post api_v1_graphql_path, params: { query: query, variables: { count: -4 } }.to_json, headers: auth_headers(nil)
 
                 json = JSON.parse(response.body)
                 data = json["data"]["randomRecipes"]
@@ -73,7 +67,7 @@ RSpec.describe "GraphQL API", type: :request do
             end
 
             it "returns the default number of random recipes when count is nil" do
-                post "/api/v1/graphql", params: { query: query, variables: { count: nil }.to_json }
+                post api_v1_graphql_path, params: { query: query, variables: { count: nil } }.to_json, headers: auth_headers(nil)
 
                 json = JSON.parse(response.body)
                 data = json["data"]["randomRecipes"]
@@ -120,11 +114,7 @@ RSpec.describe "GraphQL API", type: :request do
             end
 
             it "returns the full recipe with all associated data" do
-                post "/api/v1/graphql",
-                    params: {
-                        query: query,
-                        variables: { id: recipe.id }.to_json
-                    }
+                post api_v1_graphql_path, params: { query: query, variables: { id: recipe.id } }.to_json, headers: auth_headers(nil)
 
                 json = JSON.parse(response.body)
                 data = json["data"]["oneRecipe"]
@@ -140,6 +130,74 @@ RSpec.describe "GraphQL API", type: :request do
                 expect(ingredient_data["quantity"]).to eq(recipe_ingredient.quantity)
                 expect(ingredient_data["measurement"]["unit"]).to eq(measurement.unit)
                 expect(ingredient_data["ingredient"]["name"]).to eq(ingredient.name)
+            end
+        end
+
+        describe "allPublicCookbooks" do
+            let!(:public_cookbooks) { create_list(:user, 3) } # auto generates users initial cookbook as public
+            let!(:user_private_cookbook) { create(:cookbook, user: user, public: false) }
+            let!(:admin_private_cookbook) { create(:cookbook, user: admin, public: false) }
+
+            let(:query) do
+                <<~GRAPHQL
+                    query {
+                        publicCookbooks {
+                            id
+                            cookbookName
+                            public
+                            user {
+                                id
+                            }
+                        }
+                    }
+                GRAPHQL
+            end
+
+            context "when no user is logged in" do
+                it "returns only public cookbooks" do
+                    post api_v1_graphql_path, params: { query: query }.to_json, headers: auth_headers(nil)
+
+                    json = JSON.parse(response.body)
+                    data = json["data"]["publicCookbooks"]
+
+                    expect(response).to have_http_status(:ok)
+                    expect(data.count).to eq(5)
+                    expect(data.all? { |cb| cb["public"] == true }).to be true
+                end
+            end
+
+            context "when a regular user is logged in" do
+                it "returns public cookbooks and the user's private cookbooks" do
+                    post api_v1_graphql_path, params: { query: query }.to_json, headers: auth_headers(user)
+
+                    json = JSON.parse(response.body)
+                    data = json["data"]["publicCookbooks"]
+
+                    expect(response).to have_http_status(:ok)
+
+                    cookbook_ids = data.map { |cb| cb["id"].to_i }
+                    expect(cookbook_ids).to include(user_private_cookbook.id)
+                    expect(cookbook_ids).to include(public_cookbooks.first.cookbooks.first.id)
+                    expect(cookbook_ids).to_not include(admin_private_cookbook.id)
+                    expect(data.any? { |cb| cb["public"] == false }).to be true
+                end
+            end
+
+            context "when an admin user is logged in" do
+                it "returns all cookbooks including private ones" do
+                    post api_v1_graphql_path, params: { query: query }.to_json, headers: auth_headers(admin)
+
+                    json = JSON.parse(response.body)
+                    data = json["data"]["publicCookbooks"]
+
+                    expect(response).to have_http_status(:ok)
+
+                    cookbook_ids = data.map { |cb| cb["id"].to_i }
+                    expect(cookbook_ids).to include(admin_private_cookbook.id)
+                    expect(cookbook_ids).to include(user_private_cookbook.id)
+                    expect(cookbook_ids).to include(public_cookbooks.first.cookbooks.first.id)
+                    expect(data.any? { |cb| cb["public"] == false }).to be true
+                end
             end
         end
     end


### PR DESCRIPTION
Built cookbook resolvers for GraphQL implementation.
Three new resolvers:
- Public cookbooks resolver: gets all the public available cookbooks returning an array of them
- User cookbooks resolver: gets all cookbooks owned by a specific user
- Cookbook recipe resolver: gets all recipes associated with a single cookbook

All resolvers tested with rspec to ensure access is allowed through the cookbook policy.
Readme updated with new resolvers, the expected queries, and the expected response.