### PR TITLE
Added canEdit to README and tested its availability for single cookbooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,7 @@ Required variables:
 
 ```json
 {
-  "query": "query CookbookRecipes ($id: ID!) { cookbookRecipes (id: $id) { id cookbookName public user { id } recipes { id name image } } }",
+  "query": "query CookbookRecipes ($id: ID!) { cookbookRecipes (id: $id) { id cookbookName public canEdit user { id } recipes { id name image } } }",
   "variables": { "id": 1 },
   "operationName": "CookbookRecipes"
 }
@@ -521,6 +521,7 @@ Expected Response:
       "id": "1",
       "cookbookName": "Mediterranean Meals",
       "public": true,
+      "canEdit": true,
       "user": {
         "id": "301"
       },


### PR DESCRIPTION
Had created the canEdit variable in graphql resolvers for cookbooks, but forgot to implement it. Tested the canEdit variable in RSpec and updated the README to show its availability to the front end.