### PR TITLE
Refactor/login cookies

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ Get started by making sure that ruby is installed on your computer so that you'l
 
 ### Registering a user:
 
-Endpoint: `/graphql`
+Endpoint: `POST api/v1/graphql`
 <br><br>
 Required variables:
 
@@ -154,6 +154,11 @@ Required variables:
 }
 ```
 
+Expected Behavior:
+
+- Creates the user.
+- Returns the user information and roles in the JSON message.
+
 Expected response:
 
 ```json
@@ -166,16 +171,19 @@ Expected response:
         "lastName": "Erwin",
         "email": "SErwin@example.com"
       },
-      "token": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...", // JWT or similar
       "errors": []
     }
   }
 }
 ```
 
+<br>
+
+---
+
 ### Signing in a user:
 
-Endpoint: `/login`
+Endpoint: `POST api/v1/login`
 <br><br>
 Required variables:
 
@@ -189,11 +197,16 @@ Required variables:
 
 \*\* Either email or username is required to access the login endpoint.
 <br><br>
+Expected Behavior:
+
+- Authenticates the user.
+- Sets an HttpOnly, secure, signed cookie named `jwt` containing a JWT token for session management.
+- Returns the user information and roles in the JSON message.
+
 Expected Response:
 
 ```json
 {
-  "token": "super long encrypted token",
   "user": {
     "id": 1,
     "first_name": "Maria",
@@ -217,11 +230,83 @@ Expected Response:
 }
 ```
 
+<br>
+
+---
+
+### Signing out a user:
+
+Endpoint: DELETE `api/v1/logout`
+<br><br>
+
+Expected Behavior:
+
+- Deletes the `jwt` cookie
+- Returns a success response
+
+Expected Response:
+
+- Status 204 No Content
+
+```json
+No body
+```
+
+<br>
+
+---
+
+### Fetching current logged-in user info:
+
+Endpoint: `GET api/v1/me`
+
+Expected Behavior:
+
+- Reads the `jwt` cookie, decodes the token.
+- Returns the current user's info if authenticated.
+- Returns 401 unauthorized if no valid cookie is present.
+
+Expected Response (200 Status):
+
+```json
+{
+  "user": {
+    "id": 1,
+    "first_name": "Maria",
+    "last_name": "Heaney",
+    "username": "test user",
+    "slug": "test-user",
+    "primary_cookbook_id": 123,
+    "cookbook_count": 5
+  },
+  "roles": [
+    {
+      "id": 1,
+      "name": "user",
+      "resource_type": null,
+      "resource_id": null
+    }
+  ]
+}
+```
+
+Expected Response (401 Status):
+
+```json
+{
+  "user": null
+}
+```
+
+<br>
+
+---
+
 ### Querying for recipes:
 
 #### **All Recipes**
 
-Endpoint: `/graphql`
+Endpoint: `POST api/v1/graphql`
 <br><br>
 Fetch all recipes optionally filtered by a search string, and support pagination with limit and offset. <br>
 Required variables:
@@ -263,11 +348,15 @@ Expected Response:
 }
 ```
 
+<br>
+
+---
+
 #### **Random Recipes**
 
 An endpoint to get a random assortment of recipes, default is 5 recipes but can take in a variable to take in more or less depending on the needs of the user.
 
-Endpoint: `/graphql`
+Endpoint: `POST api/v1/graphql`
 <br><br>
 Required variables:
 
@@ -311,11 +400,15 @@ Expected Response:
 }
 ```
 
+<br>
+
+---
+
 #### **Full Recipe Data**
 
 An endpoint to get all the data associated with a single recipe.
 
-Endpoint: `/graphql`
+Endpoint: `POST api/v1/graphql`
 <br><br>
 Required variables:
 
@@ -400,7 +493,7 @@ Expected Response:
 
 An endpoint to get all the public cookbooks available and will return a list dependent on if a guest, a user, or admin is making the request. The current user is what defines what is returned.
 
-Endpoint: `/graphql`
+Endpoint: `POST api/v1/graphql`
 <br><br>
 Required variables:
 
@@ -450,7 +543,7 @@ Expected Response:
 
 An endpoint to get all the cookbooks owned by the current user.
 
-Endpoint: `/graphql`
+Endpoint: `POST api/v1/graphql`
 <br><br>
 Required variables:
 
@@ -496,11 +589,15 @@ Expected Response:
 }
 ```
 
+<br>
+
+---
+
 #### **Cookbook Recipes**
 
 An endpoint to get all the recipes associated with a specific cookbook.
 
-Endpoint: `/graphql`
+Endpoint: `POST api/v1/graphql`
 <br><br>
 Required variables:
 

--- a/app/controllers/api/v1/graphql_controller.rb
+++ b/app/controllers/api/v1/graphql_controller.rb
@@ -9,7 +9,8 @@ class Api::V1::GraphqlController < ApplicationController
     query = params[:query]
     operation_name = params[:operationName] || nil
     context = {
-      current_user: current_user
+      current_user: current_user,
+      controller: self
     }
     result = CreativeCookingApiSchema.execute(query, variables: variables, context: context, operation_name: operation_name)
     render json: result

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::SessionsController < ApplicationController
-    skip_after_action :verify_authorized, only: [ :create ]
+    skip_after_action :verify_authorized, only: [ :create, :destroy ]
 
     def create
         identifier = params[:username] || params[:email]

--- a/app/controllers/api/v1/sessions_controller.rb
+++ b/app/controllers/api/v1/sessions_controller.rb
@@ -35,7 +35,7 @@ class Api::V1::SessionsController < ApplicationController
     end
 
     def show
-        token = cookies.signed[:jwt]
+        token = Rails.env.test? ? cookies[:jwt] : cookies.signed[:jwt]
         decoded = JsonWebToken.decode(token)
         user = User.find_by(id: decoded&.dig("user_id"))
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,5 @@
 class ApplicationController < ActionController::API
+    include ActionController::Cookies
     include Pundit::Authorization
     before_action :set_current_user
     after_action :verify_authorized

--- a/app/graphql/mutations/register_user.rb
+++ b/app/graphql/mutations/register_user.rb
@@ -18,10 +18,16 @@ module Mutations
           )
 
           if user.save
-            token = JsonWebToken.encode({ user_id: user.id, roles: user.roles })
+            token = JsonWebToken.encode({ user_id: user.id })
+            context[:controller].send(:cookies).signed[:jwt] = {
+              value: token,
+              httponly: true,
+              secure: Rails.env.production?,
+              same_site: :lax
+            }
+
             {
               user: user,
-              token: token,
               errors: []
             }
           else

--- a/app/policies/graphql_policy.rb
+++ b/app/policies/graphql_policy.rb
@@ -1,5 +1,0 @@
-class GraphqlPolicy < ApplicationPolicy
-    def execute?
-        true
-    end
-end

--- a/app/services/json_web_token.rb
+++ b/app/services/json_web_token.rb
@@ -9,8 +9,10 @@ class JsonWebToken
     end
 
     def self.decode(token)
-        decoded = JWT.decode(token, SECRET_KEY, true, { algorithm: "HS256" }) rescue nil
-        raise JWT::DecodeError, "Invalid token" if decoded.nil?
+        decoded = JWT.decode(token, SECRET_KEY, true, { algorithm: "HS256" })
         HashWithIndifferentAccess.new(decoded.first)
+    rescue JWT::DecodeError => e
+        Rails.logger.warn("JWT Decode failed: #{e.message}")
+        nil
     end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -37,5 +37,7 @@ module CreativeCookingApi
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+    config.middleware.use ActionDispatch::Cookies
+    config.middleware.use ActionDispatch::Session::CookieStore, key: "_your_API_session"
   end
 end

--- a/config/initializers/cors.rb
+++ b/config/initializers/cors.rb
@@ -11,6 +11,7 @@ Rails.application.config.middleware.insert_before 0, Rack::Cors do
 
     resource "*",
       headers: :any,
+      credentials: true,
       methods: [ :get, :post, :put, :patch, :delete, :options, :head ]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "/graphql", to: "graphql#execute"
       post "/login", to: "sessions#create"
+      delete "/logout", to: "sessions#destroy"
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
     namespace :v1 do
       post "/graphql", to: "graphql#execute"
       post "/login", to: "sessions#create"
+      get "/me", to: "sessions#show"
       delete "/logout", to: "sessions#destroy"
     end
   end

--- a/spec/requests/graphql_spec.rb
+++ b/spec/requests/graphql_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe "GraphQL API", type: :request do
         if user
             token = JsonWebToken.encode(user_id: user.id)
             {
-                "Authorization" => "Bearer #{token}",
+                "Cookie" => "jwt=#{token}",
                 "Content-Type" => "application/json"
             }
         else
@@ -312,7 +312,6 @@ RSpec.describe "GraphQL API", type: :request do
                                 lastName
                                 email
                             }
-                            token
                             errors
                         }
                     }
@@ -340,7 +339,6 @@ RSpec.describe "GraphQL API", type: :request do
                 data = json["data"]["registerUser"]
 
                 expect(data["user"]["email"]).to eq("testUser@example.com")
-                expect(data["token"]).to be_present
                 expect(data["errors"]).to be_empty
             end
 
@@ -363,7 +361,6 @@ RSpec.describe "GraphQL API", type: :request do
                 data = json["data"]["registerUser"]
 
                 expect(data["user"]).to be_nil
-                expect(data["token"]).to be_nil
                 expect(data["errors"]).to_not be_empty
             end
         end

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -110,8 +110,7 @@ RSpec.describe "Sessions Controller", type: :request do
             let(:token) { JsonWebToken.encode(user_id: user.id) }
 
             before do
-                headers = { "Cookie" => "jwt=#{token}" }
-                @headers = headers
+                @headers = { "Cookie" => "jwt=#{token}" }
             end
 
             it "successfully deletes the cookie and logs the user out" do
@@ -138,12 +137,11 @@ RSpec.describe "Sessions Controller", type: :request do
             let(:token) { JsonWebToken.encode(user_id: user.id) }
 
             before do
-                headers = { "Cookie" => "jwt=#{token}" }
-                @headers = headers
+                @headers = { "Cookie" => "jwt=#{token}" }
             end
 
             it "returns current user and their roles" do
-                get "/api/v1/me", headers: @headers, params: {}, as: :json
+                get "/api/v1/me", headers: @headers, as: :json
 
                 expect(response).to have_http_status(:ok)
 
@@ -180,7 +178,7 @@ RSpec.describe "Sessions Controller", type: :request do
                 expect(response).to have_http_status(:unauthorized)
 
                 data = JSON.parse(response.body)
-                expect(parsed).to eq({ "user" => nil })
+                expect(data).to eq({ "user" => nil })
             end
         end
 
@@ -193,7 +191,7 @@ RSpec.describe "Sessions Controller", type: :request do
             end
 
             it "returns unauthorized with user: nil" do
-                get "/api/v1/me", headers: @headers, params: {}, as: :json
+                get "/api/v1/me", headers: @headers, as: :json
 
                 expect(response).to have_http_status(:unauthorized)
 

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -107,11 +107,12 @@ describe "Sessions Controller", type: :request do
         let(:token) { JsonWebToken.encode(user_id: user.id) }
 
         before do
-            cookies.signed[:jwt] = token
+            headers = { "Cookie" => "jwt=#{token}" }
+            @headers = headers
         end
 
         it "successfully deletes the cookie and logs the user out" do
-            delete "/api/v1/logout", headers: { "Cookie" => "jwt=#{token}" }, credentials: "include"
+            delete "/api/v1/logout", headers: @headers, params: {}, as: :json
 
             expect(response).to have_http_status(:no_content)
 
@@ -124,7 +125,7 @@ describe "Sessions Controller", type: :request do
             delete "/api/v1/logout"
 
             expect(response).to have_http_status(:bad_request)
-            expect(JSON.parse(resonse.body)).to include("error" => "No session found")
+            expect(JSON.parse(response.body)).to include("error" => "No session found")
         end
     end
 end

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -5,85 +5,106 @@ describe "Sessions Controller", type: :request do
     let!(:cookbook1) { create(:cookbook, user: user) }
     let!(:cookbook2) { create(:cookbook, user: user) }
 
-    it "logs in a user with valid email and password" do
-        post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
-
-        expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to include("token", "user")
-    end
-
-    it "logs in a user with valid username and password" do
-        post "/api/v1/login", params: { username: user.user_name, password: "Passwords123!" }
-
-        expect(response).to have_http_status(:ok)
-        expect(JSON.parse(response.body)).to include("token", "user")
-    end
-
-    it "rejects login with wrong password" do
-        post "/api/v1/login", params: { email: user.email, password: "wrongpass" }
-
-        expect(response).to have_http_status(:unauthorized)
-        expect(JSON.parse(response.body)).to include("error")
-    end
-
-    it "rejects login with wrong password" do
-        post "/api/v1/login", params: { username: user.user_name, password: "wrongpass" }
-
-        expect(response).to have_http_status(:unauthorized)
-        expect(JSON.parse(response.body)).to include("error")
-    end
-
-    it "returns a valid JSON response with primary_cookbook_id and cookbook_count" do
-        post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
-
-        expect(response).to have_http_status(:ok)
-
-        json = JSON.parse(response.body)
-
-        # Check keys exist
-        expect(json).to include("token", "user", "roles")
-
-        user_data = json["user"]
-
-        expect(user_data).to include(
-            "id",
-            "first_name",
-            "last_name",
-            "username",
-            "slug",
-            "primary_cookbook_id",
-            "cookbook_count"
-        )
-
-        expect(user_data["id"]).to be_a(Integer)
-        expect(user_data["first_name"]).to be_a(String)
-        expect(user_data["last_name"]).to be_a(String)
-        expect(user_data["username"]).to be_a(String)
-        expect(user_data["slug"]).to be_a(String)
-        expect(user_data["primary_cookbook_id"]).to be_a(Integer).or be_nil
-        expect(user_data["cookbook_count"]).to eq(3)
-    end
-
-    context "when user has no cookbooks" do
-        let!(:user_without_cookbooks) { create(:user) }
-
-        let(:params) do
-            {
-                username: user_without_cookbooks.user_name,
-                password: user_without_cookbooks.password
-            }
-        end
-
-        it "returns nil for primary_cookbook_id and zero for cookbook_count" do
-            Cookbook.where(user_id: user_without_cookbooks.id).delete_all
-            post "/api/v1/login", params: params
+    context "When user attempts to login" do
+        it "logs in a user with valid email and password" do
+            post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
 
             expect(response).to have_http_status(:ok)
+            expect(JSON.parse(response.body)).to include("user")
+            expect(JSON.parse(response.body)).not_to include("token")
+
+            set_cookie_header = response.headers["Set-Cookie"]
+            expect(set_cookie_header).to include("jwt=")
+            expect(set_cookie_header).to include("httponly")
+            expect(set_cookie_header).to include("samesite=lax")
+            expect(set_cookie_header).to include("Secure") if Rails.env.production?
+        end
+
+        it "logs in a user with valid username and password" do
+            post "/api/v1/login", params: { username: user.user_name, password: "Passwords123!" }
+
+            expect(response).to have_http_status(:ok)
+            expect(JSON.parse(response.body)).to include("user")
+            expect(JSON.parse(response.body)).not_to include("token")
+
+            set_cookie_header = response.headers["Set-Cookie"]
+            expect(set_cookie_header).to include("jwt=")
+            expect(set_cookie_header).to include("httponly")
+            expect(set_cookie_header).to include("samesite=lax")
+            expect(set_cookie_header).to include("Secure") if Rails.env.production?
+        end
+
+        it "rejects login with wrong password" do
+            post "/api/v1/login", params: { email: user.email, password: "wrongpass" }
+
+            expect(response).to have_http_status(:unauthorized)
+            expect(JSON.parse(response.body)).to include("error")
+        end
+
+        it "rejects login with wrong password" do
+            post "/api/v1/login", params: { username: user.user_name, password: "wrongpass" }
+
+            expect(response).to have_http_status(:unauthorized)
+            expect(JSON.parse(response.body)).to include("error")
+        end
+
+        it "returns a valid JSON response with primary_cookbook_id and cookbook_count" do
+            post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
+
+            expect(response).to have_http_status(:ok)
+
             json = JSON.parse(response.body)
+
+            # Check keys exist
+            expect(json).to include("user", "roles")
+
             user_data = json["user"]
 
-            expect(user_data["primary_cookbook_id"]).to be_nil
-            expect(user_data["cookbook_count"]).to eq(0)
+            expect(user_data).to include(
+                "id",
+                "first_name",
+                "last_name",
+                "username",
+                "slug",
+                "primary_cookbook_id",
+                "cookbook_count"
+            )
+
+            expect(user_data["id"]).to be_a(Integer)
+            expect(user_data["first_name"]).to be_a(String)
+            expect(user_data["last_name"]).to be_a(String)
+            expect(user_data["username"]).to be_a(String)
+            expect(user_data["slug"]).to be_a(String)
+            expect(user_data["primary_cookbook_id"]).to be_a(Integer).or be_nil
+            expect(user_data["cookbook_count"]).to eq(3)
+        end
+
+        context "when user has no cookbooks" do
+            let!(:user_without_cookbooks) { create(:user) }
+
+            let(:params) do
+                {
+                    username: user_without_cookbooks.user_name,
+                    password: user_without_cookbooks.password
+                }
+            end
+
+            it "returns nil for primary_cookbook_id and zero for cookbook_count" do
+                Cookbook.where(user_id: user_without_cookbooks.id).delete_all
+                post "/api/v1/login", params: params
+
+                expect(response).to have_http_status(:ok)
+                json = JSON.parse(response.body)
+                user_data = json["user"]
+
+                expect(user_data["primary_cookbook_id"]).to be_nil
+                expect(user_data["cookbook_count"]).to eq(0)
+            end
+        end
+    end
+
+    context "When user attempts to logout" do
+        it "successfully deletes the cookie and logs the user out" do
         end
     end
 end

--- a/spec/requests/sessions_requests_spec.rb
+++ b/spec/requests/sessions_requests_spec.rb
@@ -1,131 +1,205 @@
 require 'rails_helper'
 
-describe "Sessions Controller", type: :request do
+RSpec.describe "Sessions Controller", type: :request do
     let!(:user) { create(:user) }
     let!(:cookbook1) { create(:cookbook, user: user) }
     let!(:cookbook2) { create(:cookbook, user: user) }
 
-    context "When user attempts to login" do
-        it "logs in a user with valid email and password" do
-            post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
-
-            expect(response).to have_http_status(:ok)
-            expect(JSON.parse(response.body)).to include("user")
-            expect(JSON.parse(response.body)).not_to include("token")
-
-            set_cookie_header = response.headers["Set-Cookie"]
-            expect(set_cookie_header).to include("jwt=")
-            expect(set_cookie_header).to include("httponly")
-            expect(set_cookie_header).to include("samesite=lax")
-            expect(set_cookie_header).to include("Secure") if Rails.env.production?
-        end
-
-        it "logs in a user with valid username and password" do
-            post "/api/v1/login", params: { username: user.user_name, password: "Passwords123!" }
-
-            expect(response).to have_http_status(:ok)
-            expect(JSON.parse(response.body)).to include("user")
-            expect(JSON.parse(response.body)).not_to include("token")
-
-            set_cookie_header = response.headers["Set-Cookie"]
-            expect(set_cookie_header).to include("jwt=")
-            expect(set_cookie_header).to include("httponly")
-            expect(set_cookie_header).to include("samesite=lax")
-            expect(set_cookie_header).to include("Secure") if Rails.env.production?
-        end
-
-        it "rejects login with wrong password" do
-            post "/api/v1/login", params: { email: user.email, password: "wrongpass" }
-
-            expect(response).to have_http_status(:unauthorized)
-            expect(JSON.parse(response.body)).to include("error")
-        end
-
-        it "rejects login with wrong password" do
-            post "/api/v1/login", params: { username: user.user_name, password: "wrongpass" }
-
-            expect(response).to have_http_status(:unauthorized)
-            expect(JSON.parse(response.body)).to include("error")
-        end
-
-        it "returns a valid JSON response with primary_cookbook_id and cookbook_count" do
-            post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
-
-            expect(response).to have_http_status(:ok)
-
-            json = JSON.parse(response.body)
-
-            # Check keys exist
-            expect(json).to include("user", "roles")
-
-            user_data = json["user"]
-
-            expect(user_data).to include(
-                "id",
-                "first_name",
-                "last_name",
-                "username",
-                "slug",
-                "primary_cookbook_id",
-                "cookbook_count"
-            )
-
-            expect(user_data["id"]).to be_a(Integer)
-            expect(user_data["first_name"]).to be_a(String)
-            expect(user_data["last_name"]).to be_a(String)
-            expect(user_data["username"]).to be_a(String)
-            expect(user_data["slug"]).to be_a(String)
-            expect(user_data["primary_cookbook_id"]).to be_a(Integer).or be_nil
-            expect(user_data["cookbook_count"]).to eq(3)
-        end
-
-        context "when user has no cookbooks" do
-            let!(:user_without_cookbooks) { create(:user) }
-
-            let(:params) do
-                {
-                    username: user_without_cookbooks.user_name,
-                    password: user_without_cookbooks.password
-                }
-            end
-
-            it "returns nil for primary_cookbook_id and zero for cookbook_count" do
-                Cookbook.where(user_id: user_without_cookbooks.id).delete_all
-                post "/api/v1/login", params: params
+    describe "POST /api/v1/login" do
+        context "When user attempts to login" do
+            it "logs in a user with valid email and password" do
+                post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
 
                 expect(response).to have_http_status(:ok)
+                expect(JSON.parse(response.body)).to include("user")
+                expect(JSON.parse(response.body)).not_to include("token")
+
+                set_cookie_header = response.headers["Set-Cookie"]
+                expect(set_cookie_header).to include("jwt=")
+                expect(set_cookie_header).to include("httponly")
+                expect(set_cookie_header).to include("samesite=lax")
+                expect(set_cookie_header).to include("Secure") if Rails.env.production?
+            end
+
+            it "logs in a user with valid username and password" do
+                post "/api/v1/login", params: { username: user.user_name, password: "Passwords123!" }
+
+                expect(response).to have_http_status(:ok)
+                expect(JSON.parse(response.body)).to include("user")
+                expect(JSON.parse(response.body)).not_to include("token")
+
+                set_cookie_header = response.headers["Set-Cookie"]
+                expect(set_cookie_header).to include("jwt=")
+                expect(set_cookie_header).to include("httponly")
+                expect(set_cookie_header).to include("samesite=lax")
+                expect(set_cookie_header).to include("Secure") if Rails.env.production?
+            end
+
+            it "rejects login with wrong password" do
+                post "/api/v1/login", params: { email: user.email, password: "wrongpass" }
+
+                expect(response).to have_http_status(:unauthorized)
+                expect(JSON.parse(response.body)).to include("error")
+            end
+
+            it "rejects login with wrong password" do
+                post "/api/v1/login", params: { username: user.user_name, password: "wrongpass" }
+
+                expect(response).to have_http_status(:unauthorized)
+                expect(JSON.parse(response.body)).to include("error")
+            end
+
+            it "returns a valid JSON response with primary_cookbook_id and cookbook_count" do
+                post "/api/v1/login", params: { email: user.email, password: "Passwords123!" }
+
+                expect(response).to have_http_status(:ok)
+
                 json = JSON.parse(response.body)
+
+                # Check keys exist
+                expect(json).to include("user", "roles")
+
                 user_data = json["user"]
 
-                expect(user_data["primary_cookbook_id"]).to be_nil
-                expect(user_data["cookbook_count"]).to eq(0)
+                expect(user_data).to include(
+                    "id",
+                    "first_name",
+                    "last_name",
+                    "username",
+                    "slug",
+                    "primary_cookbook_id",
+                    "cookbook_count"
+                )
+
+                expect(user_data["id"]).to be_a(Integer)
+                expect(user_data["first_name"]).to be_a(String)
+                expect(user_data["last_name"]).to be_a(String)
+                expect(user_data["username"]).to be_a(String)
+                expect(user_data["slug"]).to be_a(String)
+                expect(user_data["primary_cookbook_id"]).to be_a(Integer).or be_nil
+                expect(user_data["cookbook_count"]).to eq(3)
+            end
+
+            context "when user has no cookbooks" do
+                let!(:user_without_cookbooks) { create(:user) }
+
+                let(:params) do
+                    {
+                        username: user_without_cookbooks.user_name,
+                        password: user_without_cookbooks.password
+                    }
+                end
+
+                it "returns nil for primary_cookbook_id and zero for cookbook_count" do
+                    Cookbook.where(user_id: user_without_cookbooks.id).delete_all
+                    post "/api/v1/login", params: params
+
+                    expect(response).to have_http_status(:ok)
+                    json = JSON.parse(response.body)
+                    user_data = json["user"]
+
+                    expect(user_data["primary_cookbook_id"]).to be_nil
+                    expect(user_data["cookbook_count"]).to eq(0)
+                end
             end
         end
     end
 
-    context "When user attempts to logout" do
-        let(:token) { JsonWebToken.encode(user_id: user.id) }
+    describe "DELETE /api/v1/logout" do
+        context "When user attempts to logout" do
+            let(:token) { JsonWebToken.encode(user_id: user.id) }
 
-        before do
-            headers = { "Cookie" => "jwt=#{token}" }
-            @headers = headers
+            before do
+                headers = { "Cookie" => "jwt=#{token}" }
+                @headers = headers
+            end
+
+            it "successfully deletes the cookie and logs the user out" do
+                delete "/api/v1/logout", headers: @headers, params: {}, as: :json
+
+                expect(response).to have_http_status(:no_content)
+
+                set_cookie_header = response.headers["Set-Cookie"]
+                expect(set_cookie_header).to include("jwt=;")
+                expect(set_cookie_header).to include("expires=")
+            end
+
+            it "returns bad request if no cookie is present" do
+                delete "/api/v1/logout"
+
+                expect(response).to have_http_status(:bad_request)
+                expect(JSON.parse(response.body)).to include("error" => "No session found")
+            end
+        end
+    end
+
+    describe "GET /api/v1/me" do
+        context "When jwt cookie is present" do
+            let(:token) { JsonWebToken.encode(user_id: user.id) }
+
+            before do
+                headers = { "Cookie" => "jwt=#{token}" }
+                @headers = headers
+            end
+
+            it "returns current user and their roles" do
+                get "/api/v1/me", headers: @headers, params: {}, as: :json
+
+                expect(response).to have_http_status(:ok)
+
+                data = JSON.parse(response.body)
+
+                expect(data).to include("user", "roles")
+
+                user_data = data["user"]
+
+                expect(user_data).to include(
+                    "id",
+                    "first_name",
+                    "last_name",
+                    "username",
+                    "slug",
+                    "primary_cookbook_id",
+                    "cookbook_count"
+                )
+
+                expect(user_data["id"]).to be_a(Integer)
+                expect(user_data["first_name"]).to be_a(String)
+                expect(user_data["last_name"]).to be_a(String)
+                expect(user_data["username"]).to be_a(String)
+                expect(user_data["slug"]).to be_a(String)
+                expect(user_data["primary_cookbook_id"]).to be_a(Integer).or be_nil
+                expect(user_data["cookbook_count"]).to eq(3)
+            end
         end
 
-        it "successfully deletes the cookie and logs the user out" do
-            delete "/api/v1/logout", headers: @headers, params: {}, as: :json
+        context "When jwt cookie is not present" do
+            it "returns unauthorized with user: nil" do
+                get "/api/v1/me"
 
-            expect(response).to have_http_status(:no_content)
+                expect(response).to have_http_status(:unauthorized)
 
-            set_cookie_header = response.headers["Set-Cookie"]
-            expect(set_cookie_header).to include("jwt=;")
-            expect(set_cookie_header).to include("expires=")
+                data = JSON.parse(response.body)
+                expect(parsed).to eq({ "user" => nil })
+            end
         end
 
-        it "returns bad request if no cookie is present" do
-            delete "/api/v1/logout"
+        context "when jwt cookie is invalid or expired" do
+            let(:token) { "not-a-valid-token" }
 
-            expect(response).to have_http_status(:bad_request)
-            expect(JSON.parse(response.body)).to include("error" => "No session found")
+            before do
+                headers = { "Cookie" => "jwt=#{token}" }
+                @headers = headers
+            end
+
+            it "returns unauthorized with user: nil" do
+                get "/api/v1/me", headers: @headers, params: {}, as: :json
+
+                expect(response).to have_http_status(:unauthorized)
+
+                data = JSON.parse(response.body)
+                expect(data).to eq({ "user" => nil })
+            end
         end
     end
 end


### PR DESCRIPTION
Reworked session control to move into cookie usage instead of sending the token via JSON.
Added logout and current user methods to the session controller 
Refactored login to sign cookie and return just user data without the token
Refactored registration in graphQL controller to remove token being sent and assign the cookie upon registration
Updated login, registration, and graphql query tests to ensure the user data is still retrievable
Created new tests for logout and current user methods
Updated CORS to ensure capatibility with new session methods
Updated README to show new methods and new returns.